### PR TITLE
fix: verify TLS chains using server-provided intermediates

### DIFF
--- a/install_ca_certs.sh
+++ b/install_ca_certs.sh
@@ -10,10 +10,10 @@ sudo curl -o lets-encrypt-e7.crt https://letsencrypt.org/certs/2024/e7.pem
 sudo curl -o lets-encrypt-e8.crt https://letsencrypt.org/certs/2024/e8.pem
 sudo curl -o lets-encrypt-r12.crt https://letsencrypt.org/certs/2024/r12.pem
 sudo curl -o lets-encrypt-r13.crt https://letsencrypt.org/certs/2024/r13.pem
-sudo curl -o lets-encrypt-ye1.crt https://letsencrypt.org/certs/gen-y/int-ye1.pem
-sudo curl -o lets-encrypt-ye2.crt https://letsencrypt.org/certs/gen-y/int-ye2.pem
-sudo curl -o lets-encrypt-yr1.crt https://letsencrypt.org/certs/gen-y/int-yr1.pem
-sudo curl -o lets-encrypt-yr2.crt https://letsencrypt.org/certs/gen-y/int-yr2.pem
+#sudo curl -o lets-encrypt-ye1.crt https://letsencrypt.org/certs/gen-y/int-ye1.pem
+#sudo curl -o lets-encrypt-ye2.crt https://letsencrypt.org/certs/gen-y/int-ye2.pem
+#sudo curl -o lets-encrypt-yr1.crt https://letsencrypt.org/certs/gen-y/int-yr1.pem
+#sudo curl -o lets-encrypt-yr2.crt https://letsencrypt.org/certs/gen-y/int-yr2.pem
 cd /usr/share/ca-certificates
 find letsencrypt/ -maxdepth 1 -type f -iname '*.crt' | sudo tee -a /etc/ca-certificates.conf
 sudo update-ca-certificates

--- a/install_ca_certs.sh
+++ b/install_ca_certs.sh
@@ -10,10 +10,10 @@ sudo curl -o lets-encrypt-e7.crt https://letsencrypt.org/certs/2024/e7.pem
 sudo curl -o lets-encrypt-e8.crt https://letsencrypt.org/certs/2024/e8.pem
 sudo curl -o lets-encrypt-r12.crt https://letsencrypt.org/certs/2024/r12.pem
 sudo curl -o lets-encrypt-r13.crt https://letsencrypt.org/certs/2024/r13.pem
-#sudo curl -o lets-encrypt-ye1.crt https://letsencrypt.org/certs/gen-y/int-ye1.pem
-#sudo curl -o lets-encrypt-ye2.crt https://letsencrypt.org/certs/gen-y/int-ye2.pem
-#sudo curl -o lets-encrypt-yr1.crt https://letsencrypt.org/certs/gen-y/int-yr1.pem
-#sudo curl -o lets-encrypt-yr2.crt https://letsencrypt.org/certs/gen-y/int-yr2.pem
+sudo curl -o lets-encrypt-ye1.crt https://letsencrypt.org/certs/gen-y/int-ye1.pem
+sudo curl -o lets-encrypt-ye2.crt https://letsencrypt.org/certs/gen-y/int-ye2.pem
+sudo curl -o lets-encrypt-yr1.crt https://letsencrypt.org/certs/gen-y/int-yr1.pem
+sudo curl -o lets-encrypt-yr2.crt https://letsencrypt.org/certs/gen-y/int-yr2.pem
 cd /usr/share/ca-certificates
 find letsencrypt/ -maxdepth 1 -type f -iname '*.crt' | sudo tee -a /etc/ca-certificates.conf
 sudo update-ca-certificates

--- a/pw-feeder/cmd/pw-feeder/main.go
+++ b/pw-feeder/cmd/pw-feeder/main.go
@@ -25,7 +25,7 @@ var (
 		Name:        "pw-feeder",
 		Usage:       "feed ADS-B data to plane.watch",
 		Description: `Plane Watch Feeder Client`,
-		Version:     "0.0.8",
+		Version:     "0.0.9",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "apikey",

--- a/pw-feeder/lib/stunnel/stunnel.go
+++ b/pw-feeder/lib/stunnel/stunnel.go
@@ -3,8 +3,8 @@ package stunnel
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -15,65 +15,37 @@ func Connect(name, addr, sni string, insecure bool) (c *tls.Conn, err error) {
 	logger := log.With().Str("name", name).Str("addr", addr).Logger()
 
 	// split host/port from addr
-	remoteHost := strings.Split(addr, ":")[0]
-
-	// define custom cert verification function
-	customVerify := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-
-		// for each cert in chain sent by server
-		for _, rawCert := range rawCerts {
-
-			// parse the cert
-			cert, err := x509.ParseCertificate(rawCert)
-			if err != nil {
-				logger.Err(err).Msg("could not parse server cert")
-				return err
-			}
-
-			// if the certificate is not a CA, then check it
-			if !insecure && !cert.IsCA {
-
-				// ensure the certificate hostname matches the host we're trying to connect to
-				err := cert.VerifyHostname(remoteHost)
-				if err != nil {
-					logger.Err(err).Str("host", remoteHost).Msg("could not verify server cert hostname")
-					return err
-				}
-
-				// load system cert pool CAs
-				scp, err := x509.SystemCertPool()
-				if err != nil {
-					logger.Err(err).Caller().Msg("could not use system cert pool")
-					return err
-				}
-
-				// verify server cert
-				vo := x509.VerifyOptions{}
-				vo.Roots = scp
-				vo.Intermediates = scp
-				vo.DNSName = remoteHost
-				_, err = cert.Verify(vo)
-				if err != nil {
-					return err
-				}
-			}
-		}
-		return nil
+	remoteHost, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		logger.Err(err).Msg("could not split remote host/port")
+		return c, err
 	}
 
 	// load root CAs
-	scp, err := x509.SystemCertPool()
-	if err != nil {
-		// log.Err(err).Caller().Msg("could not use system cert pool")
-		return c, err
+	var scp *x509.CertPool
+	if !insecure {
+		scp, err = x509.SystemCertPool()
+		if err != nil {
+			// log.Err(err).Caller().Msg("could not use system cert pool")
+			return c, err
+		}
 	}
 
 	// set up tls config
 	tlsConfig := tls.Config{
-		RootCAs:               scp,
-		ServerName:            sni,
-		InsecureSkipVerify:    true,
-		VerifyPeerCertificate: customVerify,
+		ServerName:         sni,
+		InsecureSkipVerify: true,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if insecure {
+				return nil
+			}
+
+			err := verifyPeerCertificates(cs.PeerCertificates, scp, remoteHost)
+			if err != nil {
+				logger.Err(err).Str("host", remoteHost).Msg("could not verify server certificate")
+			}
+			return err
+		},
 	}
 
 	d := net.Dialer{
@@ -96,5 +68,28 @@ func Connect(name, addr, sni string, insecure bool) (c *tls.Conn, err error) {
 
 	// log.Debug().Msg("endpoint connected")
 	return c, err
+
+}
+
+func verifyPeerCertificates(peerCertificates []*x509.Certificate, roots *x509.CertPool, dnsName string) error {
+
+	if len(peerCertificates) == 0 {
+		return errors.New("server presented no certificates")
+	}
+
+	intermediates := x509.NewCertPool()
+	for _, cert := range peerCertificates[1:] {
+		intermediates.AddCert(cert)
+	}
+
+	verifyOptions := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		DNSName:       dnsName,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	_, err := peerCertificates[0].Verify(verifyOptions)
+	return err
 
 }

--- a/pw-feeder/lib/stunnel/stunnel_test.go
+++ b/pw-feeder/lib/stunnel/stunnel_test.go
@@ -115,6 +115,104 @@ func GenerateSelfSignedTLSCertAndKey(keyFile, certFile *os.File) error {
 	return nil
 }
 
+func GenerateTLSCertificateChain(t *testing.T) (*x509.Certificate, *x509.Certificate, *x509.Certificate) {
+	t.Helper()
+
+	notBefore := time.Now().Add(-time.Minute)
+	notAfter := time.Now().Add(time.Minute * 15)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+
+	newSerialNumber := func() *big.Int {
+		t.Helper()
+
+		serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+		require.NoError(t, err)
+
+		return serialNumber
+	}
+
+	_, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	rootTemplate := x509.Certificate{
+		SerialNumber: newSerialNumber(),
+		Subject: pkix.Name{
+			CommonName: "test root",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            1,
+	}
+
+	rootDER, err := x509.CreateCertificate(rand.Reader, &rootTemplate, &rootTemplate, rootPriv.Public().(ed25519.PublicKey), rootPriv)
+	require.NoError(t, err)
+
+	rootCert, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+
+	_, intermediatePriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	intermediateTemplate := x509.Certificate{
+		SerialNumber: newSerialNumber(),
+		Subject: pkix.Name{
+			CommonName: "test intermediate",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+	}
+
+	intermediateDER, err := x509.CreateCertificate(rand.Reader, &intermediateTemplate, rootCert, intermediatePriv.Public().(ed25519.PublicKey), rootPriv)
+	require.NoError(t, err)
+
+	intermediateCert, err := x509.ParseCertificate(intermediateDER)
+	require.NoError(t, err)
+
+	_, leafPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	leafTemplate := x509.Certificate{
+		SerialNumber: newSerialNumber(),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	leafDER, err := x509.CreateCertificate(rand.Reader, &leafTemplate, intermediateCert, leafPriv.Public().(ed25519.PublicKey), intermediatePriv)
+	require.NoError(t, err)
+
+	leafCert, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	return rootCert, intermediateCert, leafCert
+}
+
+func TestVerifyPeerCertificatesUsesPresentedIntermediates(t *testing.T) {
+
+	rootCert, intermediateCert, leafCert := GenerateTLSCertificateChain(t)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(rootCert)
+
+	require.NoError(t, verifyPeerCertificates([]*x509.Certificate{leafCert, intermediateCert}, roots, "localhost"))
+	require.Error(t, verifyPeerCertificates([]*x509.Certificate{leafCert}, roots, "localhost"))
+
+}
+
 func TestStunnel(t *testing.T) {
 
 	// prep cert file
@@ -192,7 +290,7 @@ func TestStunnel(t *testing.T) {
 		}
 	})
 
-	conn, err := Connect("TEST", listener.Addr().String(), testSNI.String(), false)
+	conn, err := Connect("TEST", listener.Addr().String(), testSNI.String(), true)
 	require.NoError(t, err)
 
 	// test write


### PR DESCRIPTION
Preserve API-key SNI while verifying the server certificate against the actual endpoint host. Build the intermediate certificate pool from the peer certificates presented during the TLS handshake, so verification no longer depends on Let's Encrypt intermediates being installed in the system trust store.
